### PR TITLE
Remove spaces around strict_types

### DIFF
--- a/PreviousNextDrupal/ruleset.xml
+++ b/PreviousNextDrupal/ruleset.xml
@@ -44,7 +44,7 @@
     <!-- SlevomatCodingStandard.TypeHints -->
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
-            <property name="spacesCountAroundEqualsSign" type="int" value="1" />
+            <property name="spacesCountAroundEqualsSign" type="int" value="0" />
         </properties>
     </rule>
 

--- a/tests/Ignore/Base.php
+++ b/tests/Ignore/Base.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDocCommentSniffTest.php
+++ b/tests/Ignore/IgnoreDocCommentSniffTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalArraysArrayLongLineDeclarationTest.php
+++ b/tests/Ignore/IgnoreDrupalArraysArrayLongLineDeclarationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalCommentingClassCommentShortTest.php
+++ b/tests/Ignore/IgnoreDrupalCommentingClassCommentShortTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalCommentingFunctionCommentTest.php
+++ b/tests/Ignore/IgnoreDrupalCommentingFunctionCommentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalCommentingTodoCommentTodoFormatTest.php
+++ b/tests/Ignore/IgnoreDrupalCommentingTodoCommentTodoFormatTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalCommentingVariableCommentMissingTest.php
+++ b/tests/Ignore/IgnoreDrupalCommentingVariableCommentMissingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreUnreachableTest.php
+++ b/tests/Ignore/IgnoreUnreachableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/fixtures/IgnoreDocCommentSniff.php
+++ b/tests/Ignore/fixtures/IgnoreDocCommentSniff.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore\fixtures;
 

--- a/tests/Ignore/fixtures/IgnoreDrupalArraysArrayLongLineDeclaration.php
+++ b/tests/Ignore/fixtures/IgnoreDrupalArraysArrayLongLineDeclaration.php
@@ -1,5 +1,5 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 $foo = ['Lorem ipsum dolor sit amet, consectetur adipiscing elit', 'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'];

--- a/tests/Ignore/fixtures/IgnoreDrupalCommentingClassCommentShort.php
+++ b/tests/Ignore/fixtures/IgnoreDrupalCommentingClassCommentShort.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore\fixtures;
 

--- a/tests/Ignore/fixtures/IgnoreDrupalCommentingFunctionComment_IncorrectParamVarName.php
+++ b/tests/Ignore/fixtures/IgnoreDrupalCommentingFunctionComment_IncorrectParamVarName.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * @param class-string $a

--- a/tests/Ignore/fixtures/IgnoreDrupalCommentingFunctionComment_InvalidReturn.php
+++ b/tests/Ignore/fixtures/IgnoreDrupalCommentingFunctionComment_InvalidReturn.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * @return class-string

--- a/tests/Ignore/fixtures/IgnoreDrupalCommentingTodoCommentTodoFormat.php
+++ b/tests/Ignore/fixtures/IgnoreDrupalCommentingTodoCommentTodoFormat.php
@@ -1,5 +1,5 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 // @TODO: fix this or that.

--- a/tests/Ignore/fixtures/IgnoreDrupalCommentingVariableCommentMissing.php
+++ b/tests/Ignore/fixtures/IgnoreDrupalCommentingVariableCommentMissing.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore\fixtures;
 

--- a/tests/Ignore/fixtures/IgnoreUnreachable.php
+++ b/tests/Ignore/fixtures/IgnoreUnreachable.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore\fixtures;
 

--- a/tests/Sniffs/AlphabeticallySortedUsesTest.php
+++ b/tests/Sniffs/AlphabeticallySortedUsesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/Base.php
+++ b/tests/Sniffs/Base.php
@@ -4,7 +4,7 @@
 // rule of this standard until it has been reworked.
 // @codingStandardsIgnoreFile
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/ClassStructureTest.php
+++ b/tests/Sniffs/ClassStructureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/DrupalRulesetTest.php
+++ b/tests/Sniffs/DrupalRulesetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/FunctionClosingBraceSpacingBeforeCloseTest.php
+++ b/tests/Sniffs/FunctionClosingBraceSpacingBeforeCloseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/FunctionOpeningBraceSpaceSpacingAfterTest.php
+++ b/tests/Sniffs/FunctionOpeningBraceSpaceSpacingAfterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/RequireMultiLineMethodSignatureTest.php
+++ b/tests/Sniffs/RequireMultiLineMethodSignatureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/RequireTrailingCommaInCallTest.php
+++ b/tests/Sniffs/RequireTrailingCommaInCallTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/RequireTrailingCommaInDeclarationTest.php
+++ b/tests/Sniffs/RequireTrailingCommaInDeclarationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/ReturnTypeHintSpacingTest.php
+++ b/tests/Sniffs/ReturnTypeHintSpacingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/ReturnTypeHintTest.php
+++ b/tests/Sniffs/ReturnTypeHintTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/StrictTypesTest.php
+++ b/tests/Sniffs/StrictTypesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/UnusedInheritedVariablePassedToClosureTest.php
+++ b/tests/Sniffs/UnusedInheritedVariablePassedToClosureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/fixtures/AlphabeticallySortedUsesError.php
+++ b/tests/Sniffs/fixtures/AlphabeticallySortedUsesError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/AlphabeticallySortedUsesNoError.php
+++ b/tests/Sniffs/fixtures/AlphabeticallySortedUsesNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/ClassStructureError.php
+++ b/tests/Sniffs/fixtures/ClassStructureError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/ClassStructureNoError.php
+++ b/tests/Sniffs/fixtures/ClassStructureNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/DrupalRulesetError.php
+++ b/tests/Sniffs/fixtures/DrupalRulesetError.php
@@ -1,5 +1,5 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 if (true) $a = 1;

--- a/tests/Sniffs/fixtures/DrupalRulesetNoError.php
+++ b/tests/Sniffs/fixtures/DrupalRulesetNoError.php
@@ -5,7 +5,7 @@
  * A passing fixture.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 if (TRUE) {
   $a = 1;

--- a/tests/Sniffs/fixtures/FunctionClosingBraceSpacingBeforeCloseError.php
+++ b/tests/Sniffs/fixtures/FunctionClosingBraceSpacingBeforeCloseError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/FunctionClosingBraceSpacingBeforeCloseNoError.php
+++ b/tests/Sniffs/fixtures/FunctionClosingBraceSpacingBeforeCloseNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/FunctionOpeningBraceSpaceSpacingAfterError.php
+++ b/tests/Sniffs/fixtures/FunctionOpeningBraceSpaceSpacingAfterError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/FunctionOpeningBraceSpaceSpacingAfterNoError.php
+++ b/tests/Sniffs/fixtures/FunctionOpeningBraceSpaceSpacingAfterNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/RequireMultiLineMethodSignatureError.php
+++ b/tests/Sniffs/fixtures/RequireMultiLineMethodSignatureError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/RequireMultiLineMethodSignatureNoError.php
+++ b/tests/Sniffs/fixtures/RequireMultiLineMethodSignatureNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/RequireTrailingCommaInCallError.php
+++ b/tests/Sniffs/fixtures/RequireTrailingCommaInCallError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 hello(
   'foo',

--- a/tests/Sniffs/fixtures/RequireTrailingCommaInCallNoError.php
+++ b/tests/Sniffs/fixtures/RequireTrailingCommaInCallNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 hello(
   'foo',

--- a/tests/Sniffs/fixtures/RequireTrailingCommaInDeclarationError.php
+++ b/tests/Sniffs/fixtures/RequireTrailingCommaInDeclarationError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/RequireTrailingCommaInDeclarationNoError.php
+++ b/tests/Sniffs/fixtures/RequireTrailingCommaInDeclarationNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/RequireTrailingCommaInDeclarationSingleLineNoError.php
+++ b/tests/Sniffs/fixtures/RequireTrailingCommaInDeclarationSingleLineNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/ReturnTypeHintIgnoreTraversable.php
+++ b/tests/Sniffs/fixtures/ReturnTypeHintIgnoreTraversable.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * A function.

--- a/tests/Sniffs/fixtures/ReturnTypeHintNoError.php
+++ b/tests/Sniffs/fixtures/ReturnTypeHintNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * A function.

--- a/tests/Sniffs/fixtures/ReturnTypeHintSpacingError.php
+++ b/tests/Sniffs/fixtures/ReturnTypeHintSpacingError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * A function.

--- a/tests/Sniffs/fixtures/ReturnTypeHintSpacingNoError.php
+++ b/tests/Sniffs/fixtures/ReturnTypeHintSpacingNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * A function.

--- a/tests/Sniffs/fixtures/ReturnTypeHintUseless.php
+++ b/tests/Sniffs/fixtures/ReturnTypeHintUseless.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * A function.

--- a/tests/Sniffs/fixtures/ReturnTypeHintUselessWithDescription.php
+++ b/tests/Sniffs/fixtures/ReturnTypeHintUselessWithDescription.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * A function.

--- a/tests/Sniffs/fixtures/StrictTypesNoError.php
+++ b/tests/Sniffs/fixtures/StrictTypesNoError.php
@@ -1,3 +1,3 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);

--- a/tests/Sniffs/fixtures/StrictTypesSpacing.php
+++ b/tests/Sniffs/fixtures/StrictTypesSpacing.php
@@ -1,3 +1,3 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);

--- a/tests/Sniffs/fixtures/UnusedInheritedVariablePassedToClosureError.php
+++ b/tests/Sniffs/fixtures/UnusedInheritedVariablePassedToClosureError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/Sniffs/fixtures/UnusedInheritedVariablePassedToClosureNoError.php
+++ b/tests/Sniffs/fixtures/UnusedInheritedVariablePassedToClosureNoError.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Sniffs\fixtures;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 error_reporting(E_ALL);
 


### PR DESCRIPTION
To be in line with Drupal Core.

See https://www.drupal.org/node/3402544