### PR TITLE
Remove spaces around strict_types=1

### DIFF
--- a/PreviousNextDrupal/ruleset.xml
+++ b/PreviousNextDrupal/ruleset.xml
@@ -44,7 +44,7 @@
     <!-- SlevomatCodingStandard.TypeHints -->
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
-            <property name="spacesCountAroundEqualsSign" type="int" value="1" />
+            <property name="spacesCountAroundEqualsSign" type="int" value="0" />
         </properties>
     </rule>
 

--- a/tests/Ignore/Base.php
+++ b/tests/Ignore/Base.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDocCommentSniffTest.php
+++ b/tests/Ignore/IgnoreDocCommentSniffTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalArraysArrayLongLineDeclarationTest.php
+++ b/tests/Ignore/IgnoreDrupalArraysArrayLongLineDeclarationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalCommentingClassCommentShortTest.php
+++ b/tests/Ignore/IgnoreDrupalCommentingClassCommentShortTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalCommentingFunctionCommentTest.php
+++ b/tests/Ignore/IgnoreDrupalCommentingFunctionCommentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalCommentingTodoCommentTodoFormatTest.php
+++ b/tests/Ignore/IgnoreDrupalCommentingTodoCommentTodoFormatTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreDrupalCommentingVariableCommentMissingTest.php
+++ b/tests/Ignore/IgnoreDrupalCommentingVariableCommentMissingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Ignore/IgnoreUnreachableTest.php
+++ b/tests/Ignore/IgnoreUnreachableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Ignore;
 

--- a/tests/Sniffs/AlphabeticallySortedUsesTest.php
+++ b/tests/Sniffs/AlphabeticallySortedUsesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/ClassStructureTest.php
+++ b/tests/Sniffs/ClassStructureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/DrupalRulesetTest.php
+++ b/tests/Sniffs/DrupalRulesetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/FunctionClosingBraceSpacingBeforeCloseTest.php
+++ b/tests/Sniffs/FunctionClosingBraceSpacingBeforeCloseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/FunctionOpeningBraceSpaceSpacingAfterTest.php
+++ b/tests/Sniffs/FunctionOpeningBraceSpaceSpacingAfterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/RequireMultiLineMethodSignatureTest.php
+++ b/tests/Sniffs/RequireMultiLineMethodSignatureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/RequireTrailingCommaInCallTest.php
+++ b/tests/Sniffs/RequireTrailingCommaInCallTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/RequireTrailingCommaInDeclarationTest.php
+++ b/tests/Sniffs/RequireTrailingCommaInDeclarationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/ReturnTypeHintSpacingTest.php
+++ b/tests/Sniffs/ReturnTypeHintSpacingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/ReturnTypeHintTest.php
+++ b/tests/Sniffs/ReturnTypeHintTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/StrictTypesTest.php
+++ b/tests/Sniffs/StrictTypesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/Sniffs/UnusedInheritedVariablePassedToClosureTest.php
+++ b/tests/Sniffs/UnusedInheritedVariablePassedToClosureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 error_reporting(E_ALL);
 


### PR DESCRIPTION
This is the accepted Drupal coding standard https://www.drupal.org/node/3402544