### PR TITLE
⬆️ Support drupal/coder ^8 and ^9

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v4
       - uses: "shivammathur/setup-php@v2"
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v4
       - uses: "shivammathur/setup-php@v2"
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.2', '8.5']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
         dependency-versions: ['highest', 'lowest']
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.5']
     steps:
       - uses: actions/checkout@v4
       - uses: "shivammathur/setup-php@v2"
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.5']
     steps:
       - uses: actions/checkout@v4
       - uses: "shivammathur/setup-php@v2"
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.5']
         dependency-versions: ['highest', 'lowest']
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,17 @@
     "keywords": ["drupal", "phpcs"],
     "require": {
         "php": "^8.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
-        "drupal/coder": "^8.3.26",
-        "slevomat/coding-standard": "^8.16.0",
-        "squizlabs/php_codesniffer": "^3.11.1"
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
+        "drupal/coder": "^9.0",
+        "slevomat/coding-standard": "^8.28.1",
+        "squizlabs/php_codesniffer": "^4.0.1"
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.4.3",
-        "phpstan/phpstan": "^2.0.3",
-        "phpstan/phpstan-deprecation-rules": "^2.0.1",
-        "phpstan/phpstan-strict-rules": "^2",
-        "phpunit/phpunit": "^11.5"
+        "phpstan/phpstan": "^2.1.50",
+        "phpstan/phpstan-deprecation-rules": "^2.0.4",
+        "phpstan/phpstan-strict-rules": "^2.0.10",
+        "phpunit/phpunit": "^11.5.55"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,17 @@
     "keywords": ["drupal", "phpcs"],
     "require": {
         "php": "^8.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
-        "drupal/coder": "^9.0",
-        "slevomat/coding-standard": "^8.28.1",
-        "squizlabs/php_codesniffer": "^4.0.1"
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+        "drupal/coder": "^8.3.26 || ^9.0",
+        "slevomat/coding-standard": "^8.11",
+        "squizlabs/php_codesniffer": "^3.9.1 || ^4.0.1"
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.4.3",
-        "phpstan/phpstan": "^2.1.50",
-        "phpstan/phpstan-deprecation-rules": "^2.0.4",
-        "phpstan/phpstan-strict-rules": "^2.0.10",
-        "phpunit/phpunit": "^11.5.55"
+        "phpstan/phpstan": "^2.0.3",
+        "phpstan/phpstan-deprecation-rules": "^2.0.1",
+        "phpstan/phpstan-strict-rules": "^2",
+        "phpunit/phpunit": "^11.5"
     },
     "license": "MIT",
     "autoload": {

--- a/tests/Sniffs/AlphabeticallySortedUsesTest.php
+++ b/tests/Sniffs/AlphabeticallySortedUsesTest.php
@@ -21,8 +21,8 @@ final class AlphabeticallySortedUsesTest extends Base {
     self::assertSniffError($report, 8, AlphabeticallySortedUsesSniff::CODE_INCORRECT_ORDER);
   }
 
-  protected static function getSniffName(): string {
-    return 'SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses';
+  protected static function getSniffClassName(): string {
+    return AlphabeticallySortedUsesSniff::class;
   }
 
 }

--- a/tests/Sniffs/Base.php
+++ b/tests/Sniffs/Base.php
@@ -1,8 +1,7 @@
 <?php
-
+// phpcs:ignoreFile
 // Most of this file ported from slevomat/coding-standard and is immune from
 // rule of this standard until it has been reworked.
-// @codingStandardsIgnoreFile
 
 declare(strict_types=1);
 

--- a/tests/Sniffs/Base.php
+++ b/tests/Sniffs/Base.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 
+use Composer\InstalledVersions;
 use Drupal\Sniffs\Commenting\FileCommentSniff;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
@@ -23,6 +24,7 @@ use function in_array;
 use function preg_replace;
 use function sprintf;
 use function strpos;
+use function version_compare;
 
 /**
  * @codeCoverageIgnore
@@ -218,6 +220,14 @@ abstract class Base extends TestCase {
     return [
       FileCommentSniff::class,
     ];
+  }
+
+  /**
+   * Check if drupal/coder 9.x or higher is installed.
+   */
+  protected static function isCoderVersion9OrHigher(): bool {
+    $version = InstalledVersions::getVersion('drupal/coder');
+    return $version !== null && version_compare($version, '9.0.0', '>=');
   }
 
 }

--- a/tests/Sniffs/Base.php
+++ b/tests/Sniffs/Base.php
@@ -45,8 +45,9 @@ abstract class Base extends TestCase {
 
     $codeSniffer->init();
 
-    if (count($sniffProperties) > 0) {
-      $codeSniffer->ruleset->ruleset[self::getSniffName()]['properties'] = $sniffProperties;
+    $sniffName = self::getSniffName();
+    if (count($sniffProperties) > 0 && $sniffName !== null) {
+      $codeSniffer->ruleset->ruleset[$sniffName]['properties'] = $sniffProperties;
     }
 
     $sniffClassName = static::getSniffClassName();

--- a/tests/Sniffs/Base.php
+++ b/tests/Sniffs/Base.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 
-use Composer\InstalledVersions;
 use Drupal\Sniffs\Commenting\FileCommentSniff;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
@@ -24,7 +23,6 @@ use function in_array;
 use function preg_replace;
 use function sprintf;
 use function strpos;
-use function version_compare;
 
 /**
  * @codeCoverageIgnore
@@ -220,14 +218,6 @@ abstract class Base extends TestCase {
     return [
       FileCommentSniff::class,
     ];
-  }
-
-  /**
-   * Check if drupal/coder 9.x or higher is installed.
-   */
-  protected static function isCoderVersion9OrHigher(): bool {
-    $version = InstalledVersions::getVersion('drupal/coder');
-    return $version !== null && version_compare($version, '9.0.0', '>=');
   }
 
 }

--- a/tests/Sniffs/DrupalRulesetTest.php
+++ b/tests/Sniffs/DrupalRulesetTest.php
@@ -17,7 +17,11 @@ final class DrupalRulesetTest extends Base {
   public function testMissing(): void {
     $report = self::checkFile(__DIR__ . '/fixtures/DrupalRulesetError.php');
     self::assertSame(2, $report->getErrorCount());
-    self::assertSniffError($report, 5, sniffName: 'Generic.ControlStructures.InlineControlStructure', code: 'NotAllowed');
+    // Sniff name changed in drupal/coder 9.x.
+    $inlineControlSniff = self::isCoderVersion9OrHigher()
+        ? 'Generic.ControlStructures.InlineControlStructure'
+        : 'Drupal.ControlStructures.InlineControlStructure';
+    self::assertSniffError($report, 5, sniffName: $inlineControlSniff, code: 'NotAllowed');
     self::assertSniffError($report, 5, sniffName: 'Generic.PHP.UpperCaseConstant', code: 'Found');
   }
 

--- a/tests/Sniffs/DrupalRulesetTest.php
+++ b/tests/Sniffs/DrupalRulesetTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PreviousNext\CodingStandard\Tests\Sniffs;
 
+use Drupal\Sniffs\ControlStructures\InlineControlStructureSniff;
+
 /**
  * Tests inherits from Drupal ruleset.
  */
@@ -18,7 +20,7 @@ final class DrupalRulesetTest extends Base {
     $report = self::checkFile(__DIR__ . '/fixtures/DrupalRulesetError.php');
     self::assertSame(2, $report->getErrorCount());
     // Sniff removed in drupal/coder 9.x.
-    $inlineControlSniff = \class_exists(\Drupal\Sniffs\ControlStructures\InlineControlStructureSniff::class)
+    $inlineControlSniff = \class_exists(InlineControlStructureSniff::class)
         ? 'Drupal.ControlStructures.InlineControlStructure'
         : 'Generic.ControlStructures.InlineControlStructure';
     self::assertSniffError($report, 5, sniffName: $inlineControlSniff, code: 'NotAllowed');

--- a/tests/Sniffs/DrupalRulesetTest.php
+++ b/tests/Sniffs/DrupalRulesetTest.php
@@ -17,7 +17,7 @@ final class DrupalRulesetTest extends Base {
   public function testMissing(): void {
     $report = self::checkFile(__DIR__ . '/fixtures/DrupalRulesetError.php');
     self::assertSame(2, $report->getErrorCount());
-    self::assertSniffError($report, 5, sniffName: 'Drupal.ControlStructures.InlineControlStructure', code: 'NotAllowed');
+    self::assertSniffError($report, 5, sniffName: 'Generic.ControlStructures.InlineControlStructure', code: 'NotAllowed');
     self::assertSniffError($report, 5, sniffName: 'Generic.PHP.UpperCaseConstant', code: 'Found');
   }
 

--- a/tests/Sniffs/DrupalRulesetTest.php
+++ b/tests/Sniffs/DrupalRulesetTest.php
@@ -17,10 +17,10 @@ final class DrupalRulesetTest extends Base {
   public function testMissing(): void {
     $report = self::checkFile(__DIR__ . '/fixtures/DrupalRulesetError.php');
     self::assertSame(2, $report->getErrorCount());
-    // Sniff name changed in drupal/coder 9.x.
-    $inlineControlSniff = self::isCoderVersion9OrHigher()
-        ? 'Generic.ControlStructures.InlineControlStructure'
-        : 'Drupal.ControlStructures.InlineControlStructure';
+    // Sniff removed in drupal/coder 9.x.
+    $inlineControlSniff = \class_exists(\Drupal\Sniffs\ControlStructures\InlineControlStructureSniff::class)
+        ? 'Drupal.ControlStructures.InlineControlStructure'
+        : 'Generic.ControlStructures.InlineControlStructure';
     self::assertSniffError($report, 5, sniffName: $inlineControlSniff, code: 'NotAllowed');
     self::assertSniffError($report, 5, sniffName: 'Generic.PHP.UpperCaseConstant', code: 'Found');
   }


### PR DESCRIPTION
- Support both `drupal/coder` ^8.3.26 and ^9.0
- Support both `squizlabs/php_codesniffer` ^3.9.1 and ^4.0.1
- Use feature detection for conditional test assertions
- Test PHP 8.2–8.5 with lowest/highest deps

Closes #93